### PR TITLE
Curation dashboard

### DIFF
--- a/Notification.php
+++ b/Notification.php
@@ -19,8 +19,7 @@
 =========================================================================*/
 require_once BASE_PATH . '/modules/api/library/APIEnabledNotification.php';
 /** Notification manager for the curate module */
-class Curate_Notification extends ApiEnabled_Notification
-  {
+class Curate_Notification extends ApiEnabled_Notification {
   public $moduleName = 'curate';
   public $_moduleComponents = array('Api');
 
@@ -31,6 +30,15 @@ class Curate_Notification extends ApiEnabled_Notification
     $this->moduleWebroot = $fc->getBaseUrl().'/modules/'.$this->moduleName;
     $this->coreWebroot = $fc->getBaseUrl().'/core';
     $this->enableWebAPI($this->moduleName);
+    $this->addcallback("CALLBACK_CORE_GET_LEFT_LINKS", 'getLeftLink');
     }
 
+  /** adds a left link to overall Midas layout for Curation Dashboard */
+  public function getLeftLink() {
+    $fc = Zend_Controller_Front::getInstance();
+    $baseURL = $fc->getBaseUrl();
+    $moduleWebroot = $baseURL . '/' . $this->moduleName;
+    return array('Curation Dashboard' => array($moduleWebroot . '/dashboard', $baseURL . '/core/public/images/icons/ok.png'));
   }
+
+}

--- a/Notification.php
+++ b/Notification.php
@@ -31,6 +31,7 @@ class Curate_Notification extends ApiEnabled_Notification {
     $this->coreWebroot = $fc->getBaseUrl().'/core';
     $this->enableWebAPI($this->moduleName);
     $this->addcallback("CALLBACK_CORE_GET_LEFT_LINKS", 'getLeftLink');
+    $this->addcallback("CALLBACK_CORE_FOLDER_DELETED", 'folderDeleted');
     }
 
   /** adds a left link to overall Midas layout for Curation Dashboard */
@@ -39,6 +40,16 @@ class Curate_Notification extends ApiEnabled_Notification {
     $baseURL = $fc->getBaseUrl();
     $moduleWebroot = $baseURL . '/' . $this->moduleName;
     return array('Curation Dashboard' => array($moduleWebroot . '/dashboard', $baseURL . '/core/public/images/icons/ok.png'));
+  }
+
+  /** remove any curated folders if the folder is deleted */
+  public function folderDeleted($args) {
+    $folder = $args['folder'];
+    $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');
+    $curatedfolderDaos = $curatedfolderModel->findBy('folder_id', $folder->getFolderId());
+    if (count($curatedfolderDaos) > 0) {
+      $curatedfolderModel->delete($curatedfolderDaos[0]);
+    }
   }
 
 }

--- a/controllers/DashboardController.php
+++ b/controllers/DashboardController.php
@@ -30,8 +30,113 @@ class Curate_DashboardController extends Curate_AppController {
   public function indexAction() {
     $this->view->header = $this->t("Curation Dashboard");
     $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');
-    $this->view->curatedFolders = $curatedfolderModel->listAllCuratedFolders($user);
+    $this->view->isAdmin = false;
+    if ($this->logged) {
+//      echo "LOGGED";
+      $userDao = $this->userSession->Dao;
+      if ($userDao->isAdmin()) {
+//        echo "ADMIN";
+        $this->view->isAdmin = true;
+        $this->view->curatedFolders = $curatedfolderModel->listAllCuratedFolders($userDao, MIDAS_POLICY_ADMIN);
+      } else {
+//        echo "WEAK";
+        $this->view->curatedFolders = $curatedfolderModel->listAllCuratedFolders($userDao, MIDAS_POLICY_WRITE);
+      }
+    } else {
+//      echo "NOTLOGGED";
+      $userDao = null;
+    }
+//    $this->disableLayout();
   }
 
+  /** create create curated folder form */
+  public function createCuratedFolderForm($displayCommunities = array(), $displayUsers = array()) {
+    $form = new Zend_Form();
+    $form->setAction('dashboard/create')->setMethod('post');
+
+    $communitySelect = new Zend_Form_Element_Select('community');
+    $communitySelect->addMultiOptions($displayCommunities);
+
+    $name = new Zend_Form_Element_Text('name');
+    $name->setRequired(true)->addValidator('NotEmpty', true);
+
+    $description = new Zend_Form_Element_Textarea('description');
+
+    $uploader = new Zend_Form_Element_Select('uploader');
+    $uploader->addMultiOptions($displayUsers);
+
+    $submit = new  Zend_Form_Element_Submit('submit');
+    $submit->setLabel($this->t("Create"));
+
+    $form->addElements(array($communitySelect, $name, $description, $uploader, $submit));
+
+    return $form;
+  }
+
+  /** create a curated folder (ajax) */
+  public function createAction() {
+    if ($this->_request->isPost()){// && $form->isValid($this->getRequest()->getPost())) {
+        // TODO check user is admin
+        //$this->disableLayout();
+        $formParams = $this->getRequest()->getPost();
+        $name = $formParams['name'];
+        $description = $formParams['description'];
+        $communityId = $formParams['community'];
+        $uploader = $formParams['uploader'];
+        //echo $name;
+        //echo $communityId;
+        $communityModel = MidasLoader::loadModel('Community');
+        $community = $communityModel->load($communityId);
+        //var_dump($community);
+        // TODO check that foldername isn't blank and isn't taken
+
+        // create a top level folder in the community
+        $folderModel = MidasLoader::loadModel('Folder');
+        $curatedFolder = $folderModel->createFolder($name, $description, $community->getFolder());
+
+        // track the folder for curation
+        $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');
+        $curatedfolderModel->enableFolderCuration($curatedFolder);
+
+        // give the uploader user ADMIN access to the folder
+        $userModel = MidasLoader::loadModel('user');
+        $user = $userModel->load($uploader);
+        $folderpolicyuserModel = MidasLoader::loadModel('Folderpolicyuser');
+        $folderpolicyuserModel->createPolicy($user, $curatedFolder, MIDAS_POLICY_WRITE);
+
+        $this->redirect('/community/'.$communityId);
+
+
+
+
+ /*
+        //$form = $this->createCuratedFolderForm();
+        //echo 'form vali'.$form->isValid($this->getRequest()->getPost());
+        //var_dump($this->getRequest()->getPost());
+        */
+    } else {
+      $communityModel = MidasLoader::loadModel('Community');
+      $communities = $communityModel->getAll();
+      $displayCommunities = array();
+      foreach ($communities as $community) {
+        $displayCommunities[$community->getCommunityId()] = $community->getName();
+      }
+
+      $userModel = MidasLoader::loadModel('User');
+      $users = $userModel->getAll();
+      $displayUsers = array();
+      $userOrgs = array();
+      foreach ($users as $user) {
+        $displayUsers[$user->getUserId()] = $user->getFirstname() .' '. $user->getLastname();
+        $userOrgs[$user->getUserId()] = $user->getCompany();
+      }
+      // TODO how to put userOrgs in json and get it out on the page
+      $form = $this->createCuratedFolderForm($displayCommunities, $displayUsers);
+      $this->disableLayout();
+      $this->view->form = $this->getFormAsArray($form);
+      $this->view->json['userOrgs'] = $userOrgs;
+    }
+
+  }
 
 }

--- a/controllers/DashboardController.php
+++ b/controllers/DashboardController.php
@@ -1,0 +1,37 @@
+<?php
+/*=========================================================================
+ MIDAS Server
+ Copyright (c) Kitware SAS. 26 rue Louis Guérin. 69100 Villeurbanne, FRANCE
+ All rights reserved.
+ More information http://www.kitware.com
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0.txt
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+=========================================================================*/
+
+/** DashboardController */
+class Curate_DashboardController extends Curate_AppController {
+
+  /** Init Controller */
+  public function init() {
+      $this->view->activemenu = 'curate/dashboard';
+  }
+
+  /** index action */
+  public function indexAction() {
+    $this->view->header = $this->t("Curation Dashboard");
+    $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');
+    $this->view->curatedFolders = $curatedfolderModel->listAllCuratedFolders($user);
+  }
+
+
+}

--- a/controllers/DashboardController.php
+++ b/controllers/DashboardController.php
@@ -32,22 +32,20 @@ class Curate_DashboardController extends Curate_AppController {
     $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');
     $this->view->isAdmin = false;
     if ($this->logged) {
-//      echo "LOGGED";
       $userDao = $this->userSession->Dao;
       if ($userDao->isAdmin()) {
-//        echo "ADMIN";
         $this->view->isAdmin = true;
         $this->view->curatedFolders = $curatedfolderModel->listAllCuratedFolders($userDao, MIDAS_POLICY_ADMIN);
       } else {
-//        echo "WEAK";
-        $this->view->curatedFolders = $curatedfolderModel->listAllCuratedFolders($userDao, MIDAS_POLICY_WRITE);
+        $this->view->curatedFolders = $curatedfolderModel->listAllCuratedFolders($userDao, MIDAS_POLICY_READ);
       }
     } else {
-//      echo "NOTLOGGED";
       $userDao = null;
     }
-//    $this->disableLayout();
   }
+
+
+
 
   /** create create curated folder form */
   public function createCuratedFolderForm($displayCommunities = array(), $displayUsers = array()) {
@@ -106,14 +104,6 @@ class Curate_DashboardController extends Curate_AppController {
 
         $this->redirect('/community/'.$communityId);
 
-
-
-
- /*
-        //$form = $this->createCuratedFolderForm();
-        //echo 'form vali'.$form->isValid($this->getRequest()->getPost());
-        //var_dump($this->getRequest()->getPost());
-        */
     } else {
       $communityModel = MidasLoader::loadModel('Community');
       $communities = $communityModel->getAll();

--- a/controllers/components/ApiComponent.php
+++ b/controllers/components/ApiComponent.php
@@ -217,5 +217,20 @@ class Curate_ApiComponent extends AppComponent {
     return "OK";
   }
 
+  /**
+   * List all curated Folders that the passed in user has Read access to,
+   * along with the sum of sizes and download counts for all Items in
+   * the Folder subtree rooted at the Folder tracked as a Curatedfolder.
+   * @return TODO the structure of the return object
+   */
+  public function listAllCuratedFolders($args) {
+    $userDao = $this->_getUser($args);
+    $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');
+    $curatedFolders = $curatedfolderModel->listAllCuratedFolders($userDao);
+    return $curatedFolders;
+  }
+
+
+
 
 } // end class

--- a/controllers/components/ApiComponent.php
+++ b/controllers/components/ApiComponent.php
@@ -19,32 +19,27 @@
 =========================================================================*/
 
 /** Component for api methods */
-class Curate_ApiComponent extends AppComponent
-  {
+class Curate_ApiComponent extends AppComponent {
 
 
   /**
    * Helper function for verifying keys in an input array
    */
-  private function _checkKeys($keys, $values)
-    {
-    foreach($keys as $key)
-      {
-      if(!array_key_exists($key, $values))
-        {
+  private function _checkKeys($keys, $values) {
+    foreach ($keys as $key) {
+      if (!array_key_exists($key, $values)) {
         throw new Exception('Parameter '.$key.' must be set.', 400);
-        }
       }
     }
+  }
 
   /**
    * Helper function to get the user from token or session authentication
    */
-  private function _getUser($args)
-    {
+  private function _getUser($args) {
     $authComponent = MidasLoader::loadComponent('Authentication');
     return $authComponent->getUser($args, $this->userSession->Dao);
-    }
+  }
 
   /**
    * Enable curation for a folder, calling user requires ADMIN
@@ -52,30 +47,26 @@ class Curate_ApiComponent extends AppComponent
    * @param folder_id id of the folder to enable curation.
    * @return curatedfolder.
    */
-  public function enableCuration($args)
-    {
+  public function enableCuration($args) {
     $userDao = $this->_getUser($args);
-    if(!$userDao)
-      {
+    if (!$userDao) {
       throw new Exception('You must login to enable curation on a folder.', 401);
-      }
+    }
 
     $this->_checkKeys(array('folder_id'), $args);
     $folderModel = MidasLoader::loadModel('Folder');
     $folderDao = $folderModel->load($args['folder_id']);
-    if(!$folderDao)
-      {
+    if (!$folderDao) {
       throw new Exception('No folder found with that id.', 404);
-      }
-    if(!$folderModel->policyCheck($folderDao, $userDao, MIDAS_POLICY_WRITE))
-      {
+    }
+    if (!$folderModel->policyCheck($folderDao, $userDao, MIDAS_POLICY_WRITE)) {
       throw new Exception("Admin permissions required on the folder.", 401);
-      }
+    }
 
     $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');
     $curatedfolderDao = $curatedfolderModel->enableFolderCuration($folderDao);
     return $curatedfolderDao;
-    }
+  }
 
   /**
    * Disable curation for a folder, calling user requires ADMIN
@@ -84,30 +75,26 @@ class Curate_ApiComponent extends AppComponent
    * @return 1 indicating that the folder was tracked for curation
    * before it was disabled, or 0 indicating it wasn't.
    */
-  public function disableCuration($args)
-    {
+  public function disableCuration($args) {
     $userDao = $this->_getUser($args);
-    if(!$userDao)
-      {
+    if (!$userDao) {
       throw new Exception('You must login to disable curation on a folder.', 401);
-      }
+    }
 
     $this->_checkKeys(array('folder_id'), $args);
     $folderModel = MidasLoader::loadModel('Folder');
     $folderDao = $folderModel->load($args['folder_id']);
-    if(!$folderDao)
-      {
+    if (!$folderDao) {
       throw new Exception('No folder found with that id.', 404);
-      }
-    if(!$folderModel->policyCheck($folderDao, $userDao, MIDAS_POLICY_WRITE))
-      {
+    }
+    if (!$folderModel->policyCheck($folderDao, $userDao, MIDAS_POLICY_WRITE)) {
       throw new Exception("Admin permissions required on the folder.", 401);
-      }
+    }
 
     $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');
     // return int representation of boolean value
     return $curatedfolderModel->disableFolderCuration($folderDao) ? 1 : 0;
-    }
+  }
 
   /**
    * Give the ability to moderate curated folders to the passed in user,
@@ -115,29 +102,25 @@ class Curate_ApiComponent extends AppComponent
    * @param user_id id of the user to empower.
    * @return "OK" on success
    */
-  public function empowerModerator($args)
-    {
+  public function empowerModerator($args) {
     $userDao = $this->_getUser($args);
-    if(!$userDao)
-      {
+    if (!$userDao) {
       throw new Exception('You must login to empower a curation moderator.', 401);
-      }
-    if(!$userDao->getAdmin())
-      {
+    }
+    if (!$userDao->getAdmin()) {
       throw new Exception('You must be a site admin to empower a curation moderator.', 401);
-      }
+    }
 
     $this->_checkKeys(array('user_id'), $args);
     $userModel = MidasLoader::loadModel('User');
     $empoweredUserDao = $userModel->load($args['user_id']);
-    if(!$empoweredUserDao)
-      {
+    if (!$empoweredUserDao) {
       throw new Exception('No user found with that id.', 404);
-      }
+    }
     $moderatorModel = MidasLoader::loadModel('Moderator', 'curate');
     $curationModeratorDao = $moderatorModel->empowerCurationModerator($empoweredUserDao);
     return "OK";
-    }
+  }
 
   /**
    * Request that a curated folder be approved, will email all site admins and
@@ -146,50 +129,39 @@ class Curate_ApiComponent extends AppComponent
    * @param message optional message to include in the email.
    * @return "OK" on success
    */
-  public function requestApproval($args)
-    {
+  public function requestApproval($args) {
     $userDao = $this->_getUser($args);
-    if(!$userDao)
-      {
+    if (!$userDao) {
       throw new Exception('You must login to request curation approval for a folder.', 401);
-      }
+    }
 
     $this->_checkKeys(array('folder_id'), $args);
     $folderModel = MidasLoader::loadModel('Folder');
     $folderDao = $folderModel->load($args['folder_id']);
-    if(!$folderDao)
-      {
+    if (!$folderDao) {
       throw new Exception('No folder found with that id.', 404);
-      }
-    if(!$folderModel->policyCheck($folderDao, $userDao, MIDAS_POLICY_WRITE))
-      {
+    }
+    if (!$folderModel->policyCheck($folderDao, $userDao, MIDAS_POLICY_WRITE)) {
       throw new Exception("Admin permissions required on the folder.", 401);
-      }
+    }
 
     $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');
-    if(array_key_exists('message', $args))
-      {
+    if (array_key_exists('message', $args)) {
       $message = $args['message'];
-      }
-    else
-      {
+    } else {
       $message = false;
-      }
-    try
-      {
+    }
+    try {
       $curatedfolderDao = $curatedfolderModel->requestCurationApproval($folderDao, $message);
-      }
-    catch(Exception $e)
-      {
+    } catch (Exception $e) {
       // if we fail for any other reason with a -1, return a 404
-      if($e->getCode() == -1)
-        {
+      if ($e->getCode() == -1) {
         throw new Exception($e->getMessage(), 404);
-        }
       }
+    }
 
     return "OK";
-    }
+  }
 
   /**
    * Approve a curation request for a curated folder.  Will email all users
@@ -200,63 +172,50 @@ class Curate_ApiComponent extends AppComponent
    * @param message optional message to include in the email.
    * @return "OK" on success
    */
-  public function approveCuration($args)
-    {
+  public function approveCuration($args) {
     $userDao = $this->_getUser($args);
-    if(!$userDao)
-      {
+    if (!$userDao) {
       throw new Exception('You must login to approve a curation request for a folder.', 401);
-      }
+    }
 
     $this->_checkKeys(array('folder_id'), $args);
     $folderModel = MidasLoader::loadModel('Folder');
     $folderDao = $folderModel->load($args['folder_id']);
-    if(!$folderDao)
-      {
+    if (!$folderDao) {
       throw new Exception('No folder found with that id.', 404);
-      }
-
-    $userDao = $this->_getUser($args);
-    if(!$userDao)
-      {
-      throw new Exception('You must login to approve a curation request for a folder.', 401);
-      }
-
-    // require site admin or curation moderator
-    if(!$userDao->getAdmin())
-      {
-      $moderatorModel = MidasLoader::loadModel('Moderator', 'curate');
-      $moderatorDao = $moderatorModel->load($userDao->getUserId());
-      if(false == $moderatorDao)
-        {
-        throw new Exception('You must be a site admin or curation moderator to approve a curation request for a folder.', 401);
-        }
-      }
-
-    $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');
-    if(array_key_exists('message', $args))
-      {
-      $message = $args['message'];
-      }
-    else
-      {
-      $message = false;
-      }
-    try
-      {
-      $curatedfolderDao = $curatedfolderModel->approveCurationRequest($folderDao, $message);
-      }
-    catch(Exception $e)
-      {
-      // if we fail for any other reason with a -1, return a 404
-      if($e->getCode() == -1)
-        {
-        throw new Exception($e->getMessage(), 404);
-        }
-      }
-
-    return "OK";
     }
 
+    $userDao = $this->_getUser($args);
+    if (!$userDao) {
+      throw new Exception('You must login to approve a curation request for a folder.', 401);
+    }
 
-  } // end class
+    // require site admin or curation moderator
+    if (!$userDao->getAdmin()) {
+      $moderatorModel = MidasLoader::loadModel('Moderator', 'curate');
+      $moderatorDao = $moderatorModel->load($userDao->getUserId());
+      if (false == $moderatorDao) {
+        throw new Exception('You must be a site admin or curation moderator to approve a curation request for a folder.', 401);
+      }
+    }
+
+    $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');
+    if (array_key_exists('message', $args)) {
+      $message = $args['message'];
+    } else {
+      $message = false;
+    }
+    try {
+      $curatedfolderDao = $curatedfolderModel->approveCurationRequest($folderDao, $message);
+    } catch (Exception $e) {
+      // if we fail for any other reason with a -1, return a 404
+      if ($e->getCode() == -1) {
+        throw new Exception($e->getMessage(), 404);
+      }
+    }
+
+    return "OK";
+  }
+
+
+} // end class

--- a/controllers/components/ApiComponent.php
+++ b/controllers/components/ApiComponent.php
@@ -118,7 +118,7 @@ class Curate_ApiComponent extends AppComponent {
       throw new Exception('No user found with that id.', 404);
     }
     $moderatorModel = MidasLoader::loadModel('Moderator', 'curate');
-    $curationModeratorDao = $moderatorModel->empowerCurationModerator($empoweredUserDao);
+    $empowered = $moderatorModel->empowerCurationModerator($empoweredUserDao);
     return "OK";
   }
 
@@ -191,12 +191,9 @@ class Curate_ApiComponent extends AppComponent {
     }
 
     // require site admin or curation moderator
-    if (!$userDao->getAdmin()) {
-      $moderatorModel = MidasLoader::loadModel('Moderator', 'curate');
-      $moderatorDao = $moderatorModel->load($userDao->getUserId());
-      if (false == $moderatorDao) {
-        throw new Exception('You must be a site admin or curation moderator to approve a curation request for a folder.', 401);
-      }
+    $moderatorModel = MidasLoader::loadModel('Moderator', 'curate');
+    if (!$moderatorModel->isCurationModerator($userDao)) {
+      throw new Exception('You must be a site admin or curation moderator to approve a curation request for a folder.', 401);
     }
 
     $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');

--- a/models/base/CuratedfolderModelBase.php
+++ b/models/base/CuratedfolderModelBase.php
@@ -20,11 +20,10 @@
 
 require_once BASE_PATH.'/modules/curate/constant/module.php';
 /** Base model class template for the curate module */
-abstract class Curate_CuratedfolderModelBase extends Curate_AppModel
-  {
+abstract class Curate_CuratedfolderModelBase extends Curate_AppModel {
+
   /** Constructor */
-  public function __construct()
-    {
+  public function __construct() {
     parent::__construct();
     $this->_name = 'curate_curatedfolder';
     $this->_key = 'curatedfolder_id';
@@ -39,57 +38,49 @@ abstract class Curate_CuratedfolderModelBase extends Curate_AppModel
                        'parent_column' => 'folder_id',
                        'child_column' => 'folder_id'));
     $this->initialize();
-    }
+  }
 
   /** tracks the passed in folder for curation.  If the passed in folder
    * had not yet been tracked for curation, will set curate state to construction.
    * requires ADMIN access to the folder.
    */
-  function enableFolderCuration($folderDao)
-    {
-    if(is_null($folderDao))
-      {
+  function enableFolderCuration($folderDao) {
+    if (is_null($folderDao)) {
       throw new Exception('Non-null folder required to enable curation.', -1);
-      }
+    }
 
     // if already under curation return the curatedfolder
     $curatedfolderDaos = $this->findBy('folder_id', $folderDao->getFolderId());
-    if(count($curatedfolderDaos) > 0)
-      {
+    if (count($curatedfolderDaos) > 0) {
       return $curatedfolderDaos[0];
-      }
+    }
 
     $curatedfolderDao = MidasLoader::newDao('CuratedfolderDao', 'curate');
     $curatedfolderDao->setFolderId($folderDao->getFolderId());
     $curatedfolderDao->setCurationState(CURATE_STATE_CONSTRUCTION);
     $this->save($curatedfolderDao);
     return $curatedfolderDao;
-    }
+  }
 
   /** removes the passed in folder from being tracked for curation.  If the passed
    * in folder was tracked previously returns true, false otherwise.
    * requires ADMIN access to the folder.
    */
-  function disableFolderCuration($folderDao)
-    {
-    if(is_null($folderDao))
-      {
+  function disableFolderCuration($folderDao) {
+    if (is_null($folderDao)) {
       throw new Exception('Non-null folder required to disable curation.', -1);
-      }
+    }
 
     $curatedfolderDaos = $this->findBy('folder_id', $folderDao->getFolderId());
-    if(count($curatedfolderDaos) ==  0)
-      {
+    if (count($curatedfolderDaos) ==  0) {
       // if the folder isn't under curation then there is nothing to do
       return false;
-      }
-    else
-      {
+    } else {
       $curatedfolderDao = $curatedfolderDaos[0];
       $this->delete($curatedfolderDao);
       return true;
-      }
     }
+  }
 
   /** sends a notifcation email to all curation moderators requesting
    * curation approval for the passed in folder, including the passed in
@@ -97,19 +88,14 @@ abstract class Curate_CuratedfolderModelBase extends Curate_AppModel
    * sets the curation status of the folder to requested.
    * returns the curatedfolderDao.
    */
-  function requestCurationApproval($folderDao, $message = false)
-    {
-    if(is_null($folderDao))
-      {
+  function requestCurationApproval($folderDao, $message = false) {
+    if (is_null($folderDao)) {
       throw new Exception('Non-null folder required to request curation approval.', -1);
-      }
+    }
     $curatedfolderDaos = $this->findBy('folder_id', $folderDao->getFolderId());
-    if(count($curatedfolderDaos) ==  0)
-      {
+    if (count($curatedfolderDaos) ==  0) {
       throw new Exception('folder must be tracked by curation to request curation approval.', -1);
-      }
-    else
-      {
+    } else {
       $curatedfolderDao = $curatedfolderDaos[0];
       $curatedfolderDao->setCurationState(CURATE_STATE_REQUESTED);
       $this->save($curatedfolderDao);
@@ -119,35 +105,31 @@ abstract class Curate_CuratedfolderModelBase extends Curate_AppModel
       $adminDaos = $userModel->findBy('admin', '1');
 
       $moderators = array();
-      foreach($adminDaos as $admin)
-        {
+      foreach ($adminDaos as $admin) {
         $moderators[$admin->getUserId()] = $admin;
-        }
+      }
 
       // combine with all admins with those that are moderators
       $curationModeratorModel = MidasLoader::loadModel('Moderator', 'curate');
       $curationModeratorDaos = $curationModeratorModel->getAll();
-      foreach($curationModeratorDaos as $curationModerator)
-        {
+      foreach ($curationModeratorDaos as $curationModerator) {
         $moderatorUser = $curationModerator->getUser();//getUserId());
         $moderators[$moderatorUser->getUserId()] = $moderatorUser;
-        }
+      }
 
       // notify all in combined list
       $utilityComponent = MidasLoader::loadComponent('Utility');
       $body = "Hello Midas Curation Moderator,\nThe curated folder ".$folderDao->getName()." has been requested for curation approval.\n";
-      if(false != $message)
-        {
+      if (false != $message) {
         $body = $body . $message;
-        }
-      foreach($moderators as $userId => $moderator)
-        {
+      }
+      foreach ($moderators as $userId => $moderator) {
         $utilityComponent->sendEmail($moderator->getEmail(), 'Curation Approval Request', $body);
-        }
+      }
 
       return $curatedfolderDao;
-      }
     }
+  }
 
 
   /**
@@ -158,24 +140,18 @@ abstract class Curate_CuratedfolderModelBase extends Curate_AppModel
    * including the message in the notification email if the message is set.
    * returns the curatedfolderDao.
    */
-  function approveCurationRequest($folderDao, $message = false)
-    {
-    if(is_null($folderDao))
-      {
+  function approveCurationRequest($folderDao, $message = false) {
+    if (is_null($folderDao)) {
       throw new Exception('Non-null folder required to approve curation request.', -1);
-      }
+    }
     $curatedfolderDaos = $this->findBy('folder_id', $folderDao->getFolderId());
-    if(count($curatedfolderDaos) ==  0)
-      {
+    if (count($curatedfolderDaos) ==  0) {
       throw new Exception('folder must be tracked by curation to approve curation request.', -1);
-      }
-    else
-      {
+    } else {
       $curatedfolderDao = $curatedfolderDaos[0];
-      if($curatedfolderDao->getCurationState() != CURATE_STATE_REQUESTED)
-        {
+      if ($curatedfolderDao->getCurationState() != CURATE_STATE_REQUESTED) {
         throw new Exception('Curated folder must be in the REQUESTED state before approving curation request.', -1);
-        }
+      }
       $curatedfolderDao->setCurationState(CURATE_STATE_APPROVED);
       $this->save($curatedfolderDao);
 
@@ -184,29 +160,25 @@ abstract class Curate_CuratedfolderModelBase extends Curate_AppModel
       $policyDaos = $folderpolicyuserModel->findBy('folder_id', $folderDao->getFolderId());
 
       $admins = array();
-      foreach($policyDaos as $policyDao)
-        {
-        if($policyDao->getPolicy() == MIDAS_POLICY_ADMIN)
-          {
+      foreach ($policyDaos as $policyDao) {
+        if ($policyDao->getPolicy() == MIDAS_POLICY_ADMIN) {
           $admins[$policyDao->getUserId()] = $policyDao->getUser();
-          }
         }
+      }
 
       // notify all admins
       $utilityComponent = MidasLoader::loadComponent('Utility');
       $body = "Hello Midas Curated Folder Owner,\nThe curated folder ".$folderDao->getName()." has been approved for curation.\n";
-      if(false != $message)
-        {
+      if (false != $message) {
         $body = $body . $message;
-        }
-      foreach($admins as $userId => $admin)
-        {
+      }
+      foreach ($admins as $userId => $admin) {
         $utilityComponent->sendEmail($admin->getEmail(), 'Curation Approval', $body);
-        }
+      }
 
       return $curatedfolderDao;
-      }
     }
+  }
 
   /** gets all curated folders the user has the given policy access on **/
   abstract public function getAllFiltered($userDao, $policy);
@@ -219,30 +191,26 @@ abstract class Curate_CuratedfolderModelBase extends Curate_AppModel
    * including a total count of their item sizes and download counts for
    * full subtrees of the curated folder.
    */
-  function listAllCuratedFolders($userDao)
-    {
+  function listAllCuratedFolders($userDao) {
     $curatedfolderDaos = $this->getAllFiltered($userDao, MIDAS_POLICY_READ);
     $folderStats = array();
     $folderModel = MidasLoader::loadModel('Folder');
-    foreach($curatedfolderDaos as $curatedfolder)
-      {
+    foreach ($curatedfolderDaos as $curatedfolder) {
       $folder = $folderModel->load($curatedfolder->getFolderId());
       $stats = array();
       $stats['size'] = $folderModel->getSize($folder);
-      if($stats['size'] === Null)
-        {
+      if ($stats['size'] === Null) {
         $stats['size'] = 0;
-        }
+      }
       $stats['download'] = $this->getFolderDownloadCounts($folder);
-      if($stats['download'] === Null)
-        {
+      if ($stats['download'] === Null) {
         $stats['download'] = 0;
-        }
+      }
       $stats['folder_id'] = $folder->getFolderId();
       $stats['name'] = $folder->getName();
       $folderStats[] = $stats;
-      }
-    return $folderStats;
     }
-
+    return $folderStats;
   }
+
+}

--- a/models/base/CuratedfolderModelBase.php
+++ b/models/base/CuratedfolderModelBase.php
@@ -208,5 +208,16 @@ abstract class Curate_CuratedfolderModelBase extends Curate_AppModel
       }
     }
 
+  /**
+   * lists all of the curated folders that a user has Read access to.
+   */
+  function listAllCuratedFolders($userDao)
+    {
+    $curatedfolderDaos = $this->getAll($userDao);
+    return $curatedfolderDaos;
+    }
+
+
+
 
   }

--- a/models/base/CuratedfolderModelBase.php
+++ b/models/base/CuratedfolderModelBase.php
@@ -100,22 +100,8 @@ abstract class Curate_CuratedfolderModelBase extends Curate_AppModel {
       $curatedfolderDao->setCurationState(CURATE_STATE_REQUESTED);
       $this->save($curatedfolderDao);
 
-      // get all users that are admin
-      $userModel = MidasLoader::loadModel('User');
-      $adminDaos = $userModel->findBy('admin', '1');
-
-      $moderators = array();
-      foreach ($adminDaos as $admin) {
-        $moderators[$admin->getUserId()] = $admin;
-      }
-
-      // combine with all admins with those that are moderators
-      $curationModeratorModel = MidasLoader::loadModel('Moderator', 'curate');
-      $curationModeratorDaos = $curationModeratorModel->getAll();
-      foreach ($curationModeratorDaos as $curationModerator) {
-        $moderatorUser = $curationModerator->getUser();//getUserId());
-        $moderators[$moderatorUser->getUserId()] = $moderatorUser;
-      }
+      $moderatorModel = MidasLoader::loadModel('Moderator', 'curate');
+      $moderators = $moderatorModel->getAllCurationModerators();
 
       // notify all in combined list
       $utilityComponent = MidasLoader::loadComponent('Utility');

--- a/models/base/CuratedfolderModelBase.php
+++ b/models/base/CuratedfolderModelBase.php
@@ -177,8 +177,8 @@ abstract class Curate_CuratedfolderModelBase extends Curate_AppModel {
    * including a total count of their item sizes and download counts for
    * full subtrees of the curated folder.
    */
-  function listAllCuratedFolders($userDao) {
-    $curatedfolderDaos = $this->getAllFiltered($userDao, MIDAS_POLICY_READ);
+  function listAllCuratedFolders($userDao, $policy) {
+    $curatedfolderDaos = $this->getAllFiltered($userDao, $policy);//MIDAS_POLICY_READ);
     $folderStats = array();
     $folderModel = MidasLoader::loadModel('Folder');
     foreach ($curatedfolderDaos as $curatedfolder) {
@@ -192,6 +192,7 @@ abstract class Curate_CuratedfolderModelBase extends Curate_AppModel {
       if ($stats['download'] === Null) {
         $stats['download'] = 0;
       }
+      $stats['curatedfolder_id'] = $curatedfolder->getCuratedfolderId();
       $stats['folder_id'] = $folder->getFolderId();
       $stats['name'] = $folder->getName();
       $stats['curation_state'] = $curatedfolder->getCurationState();

--- a/models/base/CuratedfolderModelBase.php
+++ b/models/base/CuratedfolderModelBase.php
@@ -208,6 +208,7 @@ abstract class Curate_CuratedfolderModelBase extends Curate_AppModel {
       }
       $stats['folder_id'] = $folder->getFolderId();
       $stats['name'] = $folder->getName();
+      $stats['curation_state'] = $curatedfolder->getCurationState();
       $folderStats[] = $stats;
     }
     return $folderStats;

--- a/models/base/ModeratorModelBase.php
+++ b/models/base/ModeratorModelBase.php
@@ -37,23 +37,82 @@ abstract class Curate_ModeratorModelBase extends Curate_AppModel {
   }
 
   /**
-   * adds curation moderator ability to a user.
+   * boolean check to see if a given user is a curation moderator
+   * @return boolean indicating if the user has curation moderator powers
    */
-  function empowerCurationModerator($userDao) {
-    // if already a moderator, return that moderator rather than creating a new one
+  function isCurationModerator($userDao) {
+    if (!$userDao) {
+      return false;
+    }
+    if ($userDao->getAdmin()) {
+      return true;
+    }
     $moderatorDaos = $this->findBy('user_id', $userDao->getUserId());
     if (count($moderatorDaos) > 0) {
-      return $moderatorDaos[0];
+      return true;
     }
-
-    $curationModeratorDao = MidasLoader::newDao('ModeratorDao', 'curate');
-    $curationModeratorDao->setUserId($userDao->getUserId());
-    $this->save($curationModeratorDao);
-
-    return $curationModeratorDao;
   }
 
+  /**
+   * gets all users authorized as curation moderators.
+   * @return array of user_id to UserDao objects
+   */
+  function getAllCurationModerators() {
+    // get all users that are admin
+    $userModel = MidasLoader::loadModel('User');
+    $adminDaos = $userModel->findBy('admin', '1');
 
+    $moderators = array();
+    foreach ($adminDaos as $admin) {
+      $moderators[$admin->getUserId()] = $admin;
+    }
+
+    // combine with all admins with those that are moderators
+    $curationModeratorDaos = $this->getAll();
+    foreach ($curationModeratorDaos as $curationModerator) {
+      $moderatorUser = $curationModerator->getUser();
+      $moderators[$moderatorUser->getUserId()] = $moderatorUser;
+    }
+
+    return $moderators;
+  }
+
+  /**
+   * adds curation moderator ability to a user.
+   * @return boolean indicating success of empowerment
+   */
+  function empowerCurationModerator($userDao) {
+    if (!$userDao) {
+      return false;
+    }
+    if (!$this->isCurationModerator($userDao)) {
+      $curationModeratorDao = MidasLoader::newDao('ModeratorDao', 'curate');
+      $curationModeratorDao->setUserId($userDao->getUserId());
+      $this->save($curationModeratorDao);
+    }
+    return true;
+  }
+
+  /**
+   * removes curation moderator ability from a user.
+   * @return boolean indicating success of disempowerment
+   */
+  function disempowerCurationModerator($userDao) {
+    if (!$userDao) {
+      // something that wasn't a user is already disempowered
+      return true;
+    }
+    if ($userDao->getAdmin()) {
+      // cannot disempower admin
+      return false;
+    }
+    if ($this->isCurationModerator($userDao)) {
+      $moderatorDaos = $this->findBy('user_id', $userDao->getUserId());
+      $moderatorDao = $moderatorDaos[0];
+      $this->delete($moderatorDao);
+    }
+    return true;
+  }
 
 
 }

--- a/models/base/ModeratorModelBase.php
+++ b/models/base/ModeratorModelBase.php
@@ -19,11 +19,9 @@
 =========================================================================*/
 
 /** Base model class template for the curate module */
-abstract class Curate_ModeratorModelBase extends Curate_AppModel
-  {
+abstract class Curate_ModeratorModelBase extends Curate_AppModel {
   /** Constructor */
-  public function __construct()
-    {
+  public function __construct() {
     parent::__construct();
     $this->_name = 'curate_moderator';
     $this->_key = 'moderator_id';
@@ -36,28 +34,26 @@ abstract class Curate_ModeratorModelBase extends Curate_AppModel
                        'parent_column' => 'user_id',
                        'child_column' => 'user_id'));
     $this->initialize();
-    }
+  }
 
   /**
    * adds curation moderator ability to a user.
    */
-  function empowerCurationModerator($userDao)
-    {
+  function empowerCurationModerator($userDao) {
     // if already a moderator, return that moderator rather than creating a new one
     $moderatorDaos = $this->findBy('user_id', $userDao->getUserId());
-    if(count($moderatorDaos) > 0)
-      {
+    if (count($moderatorDaos) > 0) {
       return $moderatorDaos[0];
-      }
+    }
 
     $curationModeratorDao = MidasLoader::newDao('ModeratorDao', 'curate');
     $curationModeratorDao->setUserId($userDao->getUserId());
     $this->save($curationModeratorDao);
 
     return $curationModeratorDao;
-    }
-
-
-
-
   }
+
+
+
+
+}

--- a/models/pdo/CuratedfolderModel.php
+++ b/models/pdo/CuratedfolderModel.php
@@ -22,31 +22,23 @@ require_once BASE_PATH.'/modules/curate/models/base/CuratedfolderModelBase.php';
 require_once BASE_PATH.'/modules/curate/models/dao/CuratedfolderDao.php';
 
 /** PDO model template for the curate module */
-class Curate_CuratedfolderModel extends Curate_CuratedfolderModelBase
-  {
+class Curate_CuratedfolderModel extends Curate_CuratedfolderModelBase {
 
   /**
    * gets all curatedfolders a user has access to with the given policy
    */
-  function getAllFiltered($userDao, $policy)
-    {
-    if($userDao == null)
-      {
+  function getAllFiltered($userDao, $policy) {
+    if ($userDao == null) {
       $userId = -1;
       $admin = false;
-      }
-    else
-      {
+    } else {
       $userId = $userDao->getUserId();
       $admin = $userDao->isAdmin();
-      }
+    }
 
-    if($admin)
-      {
+    if ($admin) {
       $sql = $this->database->select();
-      }
-    else
-      {
+    } else {
       $selectFolderpolicyuser = $this->database->select()->from('curate_curatedfolder')
                 ->join('folder',
                        'folder.folder_id = curate_curatedfolder.folder_id',
@@ -72,15 +64,14 @@ class Curate_CuratedfolderModel extends Curate_CuratedfolderModelBase
                     )->where('u2g.user_id = ?', $userId).')'));
 
       $sql = $this->database->select()->union(array($selectFolderpolicyuser, $selectFolderpolicygroup));
-      }
+    }
     $rowset = $this->database->fetchAll($sql);
     $all = array();
-    foreach($rowset as $row)
-      {
+    foreach ($rowset as $row) {
       $all[] = $this->initDao('Curatedfolder', $row, 'curate');
-      }
-    return $all;
     }
+    return $all;
+  }
 
    /**
     * Get the total download counts for all items in a folder's subtree,
@@ -90,12 +81,10 @@ class Curate_CuratedfolderModel extends Curate_CuratedfolderModelBase
     * @return string
     * @throws Zend_Exception
     */
-   public function getFolderDownloadCounts($folder)
-     {
-     if (!$folder instanceof FolderDao)
-       {
+   public function getFolderDownloadCounts($folder) {
+     if (!$folder instanceof FolderDao) {
        throw new Zend_Exception("Input should be a FolderDao");
-       }
+     }
      $folders = $this->database->select()->setIntegrityCheck(false)->from(
         array('f' => 'folder'),
         array('folder_id')
@@ -119,8 +108,8 @@ class Curate_CuratedfolderModel extends Curate_CuratedfolderModelBase
      );
      $row = $this->database->fetchRow($sql);
      return $row['sum'];
-     }
+   }
 
 
 
-  }
+}

--- a/models/pdo/CuratedfolderModel.php
+++ b/models/pdo/CuratedfolderModel.php
@@ -19,8 +19,64 @@
 =========================================================================*/
 
 require_once BASE_PATH.'/modules/curate/models/base/CuratedfolderModelBase.php';
+require_once BASE_PATH.'/modules/curate/models/dao/CuratedfolderDao.php';
 
 /** PDO model template for the curate module */
 class Curate_CuratedfolderModel extends Curate_CuratedfolderModelBase
   {
+
+  /**
+   * gets all curatedfolders a user has Read access to
+   */
+  function getAll($userDao)
+    {
+
+    if($userDao == null)
+      {
+      $userId = -1;
+      $admin = false;
+      }
+    else
+      {
+      $userId = $userDao->getUserId();
+      $admin = $userDao->isAdmin();
+      }
+
+    if($admin)
+      {
+      $sql = $this->database->select();
+      }
+    else
+      {
+      $policy = MIDAS_POLICY_READ;
+      // if the user has access from any folderpolicyuser
+      $subqueryUser = $this->database->select()->setIntegrityCheck(false)->from(
+          array('cf' => 'curate_curatedfolder'))
+          ->join(array('f' => 'folder'), 'cf.folder_id = f.folder_id', array())
+          ->join(array('fpu' => 'folderpolicyuser'), 'fpu.folder_id = f.folder_id', array())
+          ->where("fpu.user_id = ? and fpu.policy >= ?", $userId, $policy);
+      // or if the user has access from any folderpolicygroup from the user's groups
+      // or if the folder is public (has a folderpolicygroup in the Anonymous group)
+      $subqueryGroup = $this->database->select()->setIntegrityCheck(false)->from(
+          array('cf' => 'curate_curatedfolder'))
+          ->join(array('f' => 'folder'), 'cf.folder_id = f.folder_id', array())
+          ->join(array('fpg' => 'folderpolicygroup'), 'fpg.folder_id = f.folder_id', array())
+          ->where("fpg.group_id = ?", MIDAS_GROUP_ANONYMOUS_KEY)
+          ->orWhere('fpg.group_id IN ('.new Zend_Db_Expr(
+            $this->database->select()->setIntegrityCheck(false)->from(
+                array('u2g' => 'user2group'),
+                array('group_id')
+            )->where('u2g.user_id = ?', $userId).')'));
+
+      $sql = $this->database->select()->union(array($subqueryUser, $subqueryGroup));
+      }
+    $rowset = $this->database->fetchAll($this->database->select());
+
+    $all = array();
+    foreach($rowset as $row)
+      {
+      $all[] = $this->initDao('Curatedfolder', $row, 'curate');
+      }
+    return $all;
+    }
   }

--- a/models/pdo/CuratedfolderModel.php
+++ b/models/pdo/CuratedfolderModel.php
@@ -39,7 +39,8 @@ class Curate_CuratedfolderModel extends Curate_CuratedfolderModelBase {
     if ($admin) {
       $sql = $this->database->select();
     } else {
-      $selectFolderpolicyuser = $this->database->select()->from('curate_curatedfolder')
+      $sql = $this->database->select()->from('curate_curatedfolder')
+      //$selectFolderpolicyuser = $this->database->select()->from('curate_curatedfolder')
                 ->join('folder',
                        'folder.folder_id = curate_curatedfolder.folder_id',
                         array())
@@ -48,7 +49,7 @@ class Curate_CuratedfolderModel extends Curate_CuratedfolderModelBase {
                         array())
                 ->where('folderpolicyuser.user_id = ?', $userId)
                 ->where('folderpolicyuser.policy >= ?', $policy);
-      $selectFolderpolicygroup = $this->database->select()->from('curate_curatedfolder')
+/*      $selectFolderpolicygroup = $this->database->select()->from('curate_curatedfolder')
                 ->join('folder',
                        'folder.folder_id = curate_curatedfolder.folder_id',
                         array())
@@ -62,8 +63,9 @@ class Curate_CuratedfolderModel extends Curate_CuratedfolderModelBase {
                            array('u2g' => 'user2group'),
                            array('group_id')
                     )->where('u2g.user_id = ?', $userId).')'));
-
-      $sql = $this->database->select()->union(array($selectFolderpolicyuser, $selectFolderpolicygroup));
+ */
+      //$sql = $this->database->select()->union(array($selectFolderpolicyuser, $selectFolderpolicygroup));
+      //$sql = $this->database->select($selectFolderpolicyuser);
     }
     $rowset = $this->database->fetchAll($sql);
     $all = array();

--- a/models/pdo/ModeratorModel.php
+++ b/models/pdo/ModeratorModel.php
@@ -22,19 +22,16 @@ require_once BASE_PATH.'/modules/curate/models/base/ModeratorModelBase.php';
 require_once BASE_PATH.'/modules/curate/models/dao/ModeratorDao.php';
 
 /** PDO model template for the curate module */
-class Curate_ModeratorModel extends Curate_ModeratorModelBase
-  {
+class Curate_ModeratorModel extends Curate_ModeratorModelBase {
 
   /** get All */
-  public function getAll()
-    {
+  public function getAll() {
     $rowset = $this->database->fetchAll($this->database->select()->order(array('moderator_id')));
     $results = array();
-    foreach($rowset as $row)
-      {
+    foreach ($rowset as $row) {
       $results[] = $this->initDao('Moderator', $row, 'curate');
-      }
-    return $results;
     }
-
+    return $results;
   }
+
+}

--- a/public/css/dashboard/curatedfolder.create.css
+++ b/public/css/dashboard/curatedfolder.create.css
@@ -1,0 +1,12 @@
+form#createCuratedFolderForm label{width:100px !important;}
+
+form#createCuratedFolderForm div#createCuratedFolderInstructions { padding-bottom: 30px;}
+
+form#createCuratedFolderForm div.communitySelect { padding-bottom: 20px;}
+
+form#createCuratedFolderForm div.curatedFolderNameElement { padding-bottom: 5px;}
+
+form#createCuratedFolderForm div.curatedFolder { padding-bottom: 20px;}
+
+form#createCuratedFolderForm div.uploadingUserSelect { padding-bottom: 30px;}
+

--- a/public/js/dashboard/createcuratefolder.js
+++ b/public/js/dashboard/createcuratefolder.js
@@ -1,0 +1,33 @@
+var midas = midas || {};
+midas.curate = midas.curate || {};
+
+
+$('#createCuratedFolderForm').ajaxForm({
+    beforeSubmit: validateCreateCuratedFolder ,
+    success: successCreateCuratedFolder
+});
+
+function validateCreateCuratedFolder(formData, jqForm, options) {
+    'use strict';
+    var form = jqForm[0];
+    var communityId = form.community.value;
+    var folderName = form.name.value;
+    if (folderName < 1) {
+        midas.createNotice('Folder name cannot be empty', 4000, 'error');
+        return false;
+    }
+    return true;
+}
+
+function successCreateCuratedFolder(responseText, statusText, xhr, form) {
+    'use strict';
+    var response = JSON.parse(responseText);
+    var created = response[0];
+    var message = response[1];
+    if (created) {
+        // redirect to dashboard
+        window.location = json.global.webroot + '/curate/dashboard';
+    } else {
+        midas.createNotice(message, 4000, 'error');
+    }
+}

--- a/public/js/dashboard/index.js
+++ b/public/js/dashboard/index.js
@@ -5,11 +5,10 @@ midas.curate = midas.curate || {};
 midas.curate.createNewCuratedFolder = function() {
     'use strict';
     if (json.global.logged) {
-        console.log('CREATE CURATED FOLDER');
         midas.loadDialog('createCuratedFolder', '/curate/dashboard/create');
         midas.showDialog('Create Curated Folder', false);
     } else {
-        console.log('NEED TO BE LOGGED IN');
+        midas.createNotice('You need to be logged in.', 4000, 'error');
     }
 };
 
@@ -23,8 +22,7 @@ midas.curate.adminApprove = function(folderId) {
                 $('#curatedFolder'+folderId+' .curationState').text('approved');
                 $('#curatedFolder'+folderId+' .curationAction').text('');
             } else {
-                // TODO handle error
-                console.log(response);
+                midas.createNotice(response.data, 4000, 'error');
             }
         }
     });
@@ -36,14 +34,12 @@ midas.curate.uploaderRequestApproval = function(folderId) {
         method: 'midas.curate.request.approval',
         args: 'folderId=' + folderId,
         success: function(response) {
-            console.log(response);
             if (response.data == 'OK') {
                 $('#curatedFolder'+folderId+' .curationState').text('requested');
                 var actionHTML = '<img src="/core/public/images/icons/time.png" style="padding-right: 5px;">wait for approval';
                 $('#curatedFolder'+folderId+' .curationAction').html(actionHTML);
             } else {
-                // TODO handle error
-                console.log(response);
+                midas.createNotice(response.data, 4000, 'error');
             }
         }
     });

--- a/public/js/dashboard/index.js
+++ b/public/js/dashboard/index.js
@@ -1,6 +1,64 @@
 var midas = midas || {};
 midas.curate = midas.curate || {};
 
+
+midas.curate.createNewCuratedFolder = function() {
+    if (json.global.logged) {
+        console.log('CREATE CURATED FOLDER');
+        midas.loadDialog('createCuratedFolder', '/curate/dashboard/create');
+        midas.showDialog('Create Curated Folder', false);
+   } else {
+        console.log('NEED TO BE LOGGED IN');
+    }
+
+
+};
+
+/*function callbackSelect(node) {
+    'use strict';
+    console.log('callback select');
+    console.log(node);
+}
+
+function callbackCheckboxes(node) {
+    'use strict';
+    console.log('callback checkboxes');
+    console.log(node);
+}*/
+midas.curate.adminApprove = function(curatedfolderId) {
+    console.log('adminApprove:'+curatedfolderId);
+    // TODO call api endpoint
+    //  check admin
+    //  change state to approved
+    //  remove write access if any
+    //  add community member read access
+    // TODO frontend
+    //  change curation state
+    //  change action
+}
+midas.curate.uploaderRequestApproval = function(curatedfolderId) {
+    console.log('uploaderRequestApproval:'+curatedfolderId);
+    // TODO call api endpoint
+    //  check user has write
+    //  change state to requested
+    //  remove write access for user, replace with user specific read
+    // TODO frontend
+    //  change curation state
+    //  change action
+}}
+
+
 $(function() {
-  $('#curateDashboardTable').show();
+    'use strict';
+    /*$('#curateDashboardTableHeaderCheckbox').qtip({
+        content: 'Check/Uncheck All'
+    });
+                        echo "  <td><input type='checkbox' class='treeCheckbox' type='curatedfolder' element='{$this->escape($curatedfolder_id)}' id='curatedfolderCheckbox{$this->escape($curatedfolder_id)}' /></td>";*/
+//    midas.browser.enableSelectAll();
+//    $('#curateDashboardTable').treeTable({});
+    $('#curateDashboardTable').show();
+    $('.curatedfolderCheckbox').change(function() {
+        // TODO get the checkbox stateg
+       console.log("check or uncheck");
+    });
 });

--- a/public/js/dashboard/index.js
+++ b/public/js/dashboard/index.js
@@ -3,62 +3,54 @@ midas.curate = midas.curate || {};
 
 
 midas.curate.createNewCuratedFolder = function() {
+    'use strict';
     if (json.global.logged) {
         console.log('CREATE CURATED FOLDER');
         midas.loadDialog('createCuratedFolder', '/curate/dashboard/create');
         midas.showDialog('Create Curated Folder', false);
-   } else {
+    } else {
         console.log('NEED TO BE LOGGED IN');
     }
-
-
 };
 
-/*function callbackSelect(node) {
+midas.curate.adminApprove = function(folderId) {
     'use strict';
-    console.log('callback select');
-    console.log(node);
+    ajaxWebApi.ajax({
+        method: 'midas.curate.approve.curation',
+        args: 'folderId=' + folderId,
+        success: function(response) {
+            if (response.data == 'OK') {
+                $('#curatedFolder'+folderId+' .curationState').text('approved');
+                $('#curatedFolder'+folderId+' .curationAction').text('');
+            } else {
+                // TODO handle error
+                console.log(response);
+            }
+        }
+    });
 }
 
-function callbackCheckboxes(node) {
+midas.curate.uploaderRequestApproval = function(folderId) {
     'use strict';
-    console.log('callback checkboxes');
-    console.log(node);
-}*/
-midas.curate.adminApprove = function(curatedfolderId) {
-    console.log('adminApprove:'+curatedfolderId);
-    // TODO call api endpoint
-    //  check admin
-    //  change state to approved
-    //  remove write access if any
-    //  add community member read access
-    // TODO frontend
-    //  change curation state
-    //  change action
+    ajaxWebApi.ajax({
+        method: 'midas.curate.request.approval',
+        args: 'folderId=' + folderId,
+        success: function(response) {
+            console.log(response);
+            if (response.data == 'OK') {
+                $('#curatedFolder'+folderId+' .curationState').text('requested');
+                var actionHTML = '<img src="/core/public/images/icons/time.png" style="padding-right: 5px;">wait for approval';
+                $('#curatedFolder'+folderId+' .curationAction').html(actionHTML);
+            } else {
+                // TODO handle error
+                console.log(response);
+            }
+        }
+    });
 }
-midas.curate.uploaderRequestApproval = function(curatedfolderId) {
-    console.log('uploaderRequestApproval:'+curatedfolderId);
-    // TODO call api endpoint
-    //  check user has write
-    //  change state to requested
-    //  remove write access for user, replace with user specific read
-    // TODO frontend
-    //  change curation state
-    //  change action
-}}
 
 
 $(function() {
     'use strict';
-    /*$('#curateDashboardTableHeaderCheckbox').qtip({
-        content: 'Check/Uncheck All'
-    });
-                        echo "  <td><input type='checkbox' class='treeCheckbox' type='curatedfolder' element='{$this->escape($curatedfolder_id)}' id='curatedfolderCheckbox{$this->escape($curatedfolder_id)}' /></td>";*/
-//    midas.browser.enableSelectAll();
-//    $('#curateDashboardTable').treeTable({});
     $('#curateDashboardTable').show();
-    $('.curatedfolderCheckbox').change(function() {
-        // TODO get the checkbox stateg
-       console.log("check or uncheck");
-    });
 });

--- a/public/js/dashboard/index.js
+++ b/public/js/dashboard/index.js
@@ -1,0 +1,6 @@
+var midas = midas || {};
+midas.curate = midas.curate || {};
+
+$(function() {
+  $('#curateDashboardTable').show();
+});

--- a/tests/controllers/ApiComponentControllerTest.php
+++ b/tests/controllers/ApiComponentControllerTest.php
@@ -79,7 +79,7 @@ class ApiControllerTest extends ControllerTestCase
 
     $resp = $this->_callJsonApi();
     $this->_assertStatusOk($resp);
-    $this->assertEquals(strlen($resp->data->token), 40);
+    $this->assertEquals(strlen($resp->data->token), 32);
 
     // **IMPORTANT** This will clear any params that were set before this
     // function was called
@@ -108,7 +108,7 @@ class ApiControllerTest extends ControllerTestCase
 
     $resp = $this->_callJsonApi();
     $this->_assertStatusOk($resp);
-    $this->assertEquals(strlen($resp->data->token), 40);
+    $this->assertEquals(strlen($resp->data->token), 32);
 
     // **IMPORTANT** This will clear any params that were set before this
     // function was called

--- a/tests/models/base/CuratedfolderModelTest.php
+++ b/tests/models/base/CuratedfolderModelTest.php
@@ -205,56 +205,120 @@ class CuratedfolderModelTest extends DatabaseTestCase
     $disabled = $curatedfolderModel->disableFolderCuration($folderDao);
     }
 
+
+  /** _trackUserReadFolders */
+  public function _trackUserReadFolders($folder, $userReadFolders, $policies)
+    {
+    foreach($policies as $userInd => $policy)
+      {
+      if($policy)
+        {
+        $userReadFolders[$userInd][] = $folder;
+        }
+      }
+    return $userReadFolders;
+    }
+
+  /** _ensureReadPolicy */
+  public function _ensureReadPolicy($folder, $users, $policies)
+    {
+    foreach($policies as $ind => $policy)
+      {
+      //echo "ind:".$ind.' policy:'.$policy.' folder:'.$folder->getName();
+      $this->assertEquals($policies[$ind], $this->Folder->policyCheck($folder, $users[$ind], MIDAS_POLICY_READ));
+      }
+    }
+
   /** testListAllCuratedFolders */
   public function testListAllCuratedFolders()
     {
-    // load some folders and enable them for curation
-    $folderDao = $this->Folder->load(1000);
-    $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');
-    $enabled = $curatedfolderModel->enableFolderCuration($folderDao);
-
     $userModel = MidasLoader::loadModel('User');
-    $userDao = $userModel->load(1);
-    $curatedFolders = $curatedfolderModel->listAllCuratedFolders($userDao);
-    $found = false;
-    foreach($curatedFolders as $curated)
+    // first user is empty, for anonymous access
+    $users = array();
+    $users[] = null;
+    foreach(range(1,3) as $userId)
       {
-      if($curated->getFolderId() == 1000)
+      $users[] = $userModel->load($userId);
+      }
+
+    $userReadFolders = array();
+    foreach(range(0,3) as $userInd)
+      {
+      $userReadFolders[] = array();
+      }
+
+    // folder 1 is read for user 3
+    $folder1 = $this->Folder->createFolder('curateFolder1', '', -1);
+    $policies = array(false, false, false, true);
+    $userReadFolders = $this->_trackUserReadFolders($folder1, $userReadFolders, $policies);
+    $this->_ensureReadPolicy($folder1, $users, $policies);
+
+    // folder 2 is read for user 3
+    // folder 2 is read for user 1 by folderpolicyuser
+    $folder2 = $this->Folder->createFolder('curateFolder2', '', -1);
+    $policies = array(false, true, false, true);
+    $userReadFolders = $this->_trackUserReadFolders($folder2, $userReadFolders, $policies);
+    $folderpolicyuserModel = MidasLoader::loadModel('Folderpolicyuser');
+    $folderpolicyuserModel->createPolicy($users[1], $folder2, MIDAS_POLICY_READ);
+    $this->_ensureReadPolicy($folder2, $users, $policies);
+
+    // folder 3 is read for user 3
+    // folder 3 is read for user 2 by folderpolicygroup
+    $folder3 = $this->Folder->createFolder('curateFolder3', '', -1);
+    $policies = array(false, false, true, true);
+    $userReadFolders = $this->_trackUserReadFolders($folder3, $userReadFolders, $policies);
+    // create a group tied to a community
+    $communityModel = MidasLoader::loadModel('Community');
+    $community = $communityModel->load(2000);
+    $groupModel = MidasLoader::loadModel('Group');
+    $group = $groupModel->createGroup($community, 'folder3readgroup');
+    $folderpolicygroupModel = MidasLoader::loadModel('Folderpolicygroup');
+    $groupModel->addUser($group, $users[2]);
+    $folderpolicygroupModel->createPolicy($group, $folder3, MIDAS_POLICY_READ);
+    $this->_ensureReadPolicy($folder3, $users, $policies);
+
+    // folder 4 is read for all users because of anonymous group
+    $folder4 = $this->Folder->createFolder('curateFolder4', '', -1);
+    $policies = array(true, true, true, true);
+    $userReadFolders = $this->_trackUserReadFolders($folder4, $userReadFolders, $policies);
+    $anonGroup = $groupModel->load(MIDAS_GROUP_ANONYMOUS_KEY);
+    $folderpolicygroupModel->createPolicy($anonGroup, $folder4, MIDAS_POLICY_READ);
+    $this->_ensureReadPolicy($folder4, $users, $policies);
+
+    // enable all folders for curation
+    $folders = array($folder1, $folder2, $folder3, $folder4);
+    $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');
+    foreach($folders as $folder)
+      {
+      $enabled = $curatedfolderModel->enableFolderCuration($folder);
+      }
+
+    // check that each user sees the correct curation folders
+    foreach($users as $userInd => $user)
+      {
+      $expectedFoldersForUser = $userReadFolders[$userInd];
+      $curatedFolders = $curatedfolderModel->listAllCuratedFolders($user);
+      $this->assertEquals(count($expectedFoldersForUser), count($curatedFolders), "Expected folders and curated folders differ in count");
+      foreach($expectedFoldersForUser as $expectedFolder)
         {
-        $found = true;
-        $this->assertEquals($curated->getCurationState(), CURATE_STATE_CONSTRUCTION);
+        $found = false;
+        foreach($curatedFolders as $curatedFolder)
+          {
+          if($expectedFolder->getFolderId() == $curatedFolder->getFolderId())
+            {
+            $found = true;
+            }
+          }
+        $this->assertTrue($found, "Did not find a match in the curated folders for expected folder with id ".$curatedFolder->getFolderId());
         }
       }
-    $this->assertTrue($found, 'did not find expected curated folder');
 
-    $curatedfolderDao = $curatedfolderModel->requestCurationApproval($folderDao);
-    $curatedFolders = $curatedfolderModel->listAllCuratedFolders($userDao);
-    $found = false;
-    foreach($curatedFolders as $curated)
+    // disable all folders for curation
+    foreach($folders as $folder)
       {
-      if($curated->getFolderId() == 1000)
-        {
-        $found = true;
-        $this->assertEquals($curated->getCurationState(), CURATE_STATE_REQUESTED);
-        }
+      $enabled = $curatedfolderModel->disableFolderCuration($folder);
       }
-    $this->assertTrue($found, 'did not find expected curated folder');
 
-    $curatedfolderDao = $curatedfolderModel->approveCurationRequest($folderDao);
-    $curatedFolders = $curatedfolderModel->listAllCuratedFolders($userDao);
-    $found = false;
-    foreach($curatedFolders as $curated)
-      {
-      if($curated->getFolderId() == 1000)
-        {
-        $found = true;
-        $this->assertEquals($curated->getCurationState(), CURATE_STATE_APPROVED);
-        }
-      }
-    $this->assertTrue($found, 'did not find expected curated folder');
-
-    // ensure this folder is not tracked for curation
-    $disabled = $curatedfolderModel->disableFolderCuration($folderDao);
     }
 
   }

--- a/tests/models/base/CuratedfolderModelTest.php
+++ b/tests/models/base/CuratedfolderModelTest.php
@@ -133,7 +133,7 @@ class CuratedfolderModelTest extends DatabaseTestCase
     $userModel = MidasLoader::loadModel('User');
     $userDao = $userModel->load(1);
     $curationModeratorModel = MidasLoader::loadModel('Moderator', 'curate');
-    $curationModeratorDao = $curationModeratorModel->empowerCurationModerator($userDao);
+    $empowered = $curationModeratorModel->empowerCurationModerator($userDao);
 
     $curatedfolderDao = $curatedfolderModel->requestCurationApproval($folderDao);
     $this->assertEquals($curatedfolderDao->getFolderId(), $folderDao->getFolderId());
@@ -180,7 +180,7 @@ class CuratedfolderModelTest extends DatabaseTestCase
     $userModel = MidasLoader::loadModel('User');
     $userDao = $userModel->load(1);
     $curationModeratorModel = MidasLoader::loadModel('Moderator', 'curate');
-    $curationModeratorDao = $curationModeratorModel->empowerCurationModerator($userDao);
+    $empowered = $curationModeratorModel->empowerCurationModerator($userDao);
 
     // approve a folder that isn't in the requested state
     try

--- a/tests/models/base/CuratedfolderModelTest.php
+++ b/tests/models/base/CuratedfolderModelTest.php
@@ -220,14 +220,31 @@ class CuratedfolderModelTest extends DatabaseTestCase
     }
 
   /** _ensureReadPolicy */
-  public function _ensureReadPolicy($folder, $users, $policies)
+  function _ensureReadPolicy($folder, $users, $policies)
     {
     foreach($policies as $ind => $policy)
       {
-      //echo "ind:".$ind.' policy:'.$policy.' folder:'.$folder->getName();
       $this->assertEquals($policies[$ind], $this->Folder->policyCheck($folder, $users[$ind], MIDAS_POLICY_READ));
       }
     }
+
+  function _createItemWithStats($itemName, $folder, $sizeBytes, $downloadCount, $expectedFolderStats, $rootCuratedFolder)
+    {
+    $itemModel = MidasLoader::loadModel('Item');
+    $item = $itemModel->createItem($itemName, $itemName, $folder);
+    $item->setSizebytes($sizeBytes);
+    $item->setDownload($downloadCount);
+    $itemModel->save($item);
+    $rootFolderKey = $rootCuratedFolder->getFolderId();
+    if(!array_key_exists($rootFolderKey, $expectedFolderStats))
+      {
+      $expectedFolderStats[$rootFolderKey] = array('size' => 0, 'download' => 0);
+      }
+    $expectedFolderStats[$rootFolderKey]['size'] += $sizeBytes;
+    $expectedFolderStats[$rootFolderKey]['download'] += $downloadCount;
+    return $expectedFolderStats;
+    }
+
 
   /** testListAllCuratedFolders */
   public function testListAllCuratedFolders()
@@ -253,6 +270,13 @@ class CuratedfolderModelTest extends DatabaseTestCase
     $userReadFolders = $this->_trackUserReadFolders($folder1, $userReadFolders, $policies);
     $this->_ensureReadPolicy($folder1, $users, $policies);
 
+    // create items and subfolders with [size, download]
+    // e.g. folder 1: item11 [1000, 1]
+    // track this mapping to root folder_id, i.e. the top level folder that all stats
+    // should accumulate up to
+    $expectedFolderStats = array();
+    $expectedFolderStats = $this->_createItemWithStats('item11', $folder1, 1000, 1, $expectedFolderStats, $folder1);
+
     // folder 2 is read for user 3
     // folder 2 is read for user 1 by folderpolicyuser
     $folder2 = $this->Folder->createFolder('curateFolder2', '', -1);
@@ -261,6 +285,15 @@ class CuratedfolderModelTest extends DatabaseTestCase
     $folderpolicyuserModel = MidasLoader::loadModel('Folderpolicyuser');
     $folderpolicyuserModel->createPolicy($users[1], $folder2, MIDAS_POLICY_READ);
     $this->_ensureReadPolicy($folder2, $users, $policies);
+
+    // subfolder21
+    $folder21 = $this->Folder->createFolder('subfolder21', '', $folder2->getFolderId());
+    // item211: [2000, 10]
+    $expectedFolderStats = $this->_createItemWithStats('item211', $folder21, 2000, 10, $expectedFolderStats, $folder2);
+    // subfolder22
+    $folder22 = $this->Folder->createFolder('subfolder22', '', $folder2->getFolderId());
+    // item221: [3000, 20]
+    $expectedFolderStats = $this->_createItemWithStats('item221', $folder22, 3000, 20, $expectedFolderStats, $folder2);
 
     // folder 3 is read for user 3
     // folder 3 is read for user 2 by folderpolicygroup
@@ -277,6 +310,25 @@ class CuratedfolderModelTest extends DatabaseTestCase
     $folderpolicygroupModel->createPolicy($group, $folder3, MIDAS_POLICY_READ);
     $this->_ensureReadPolicy($folder3, $users, $policies);
 
+    // item31: [2000, 2]
+    // item32: [2000, 3]
+    $expectedFolderStats = $this->_createItemWithStats('item31', $folder3, 2000, 2, $expectedFolderStats, $folder3);
+    $expectedFolderStats = $this->_createItemWithStats('item32', $folder3, 2000, 3, $expectedFolderStats, $folder3);
+    // subfolder31
+    $folder31 = $this->Folder->createFolder('subfolder31', '', $folder3->getFolderId());
+    // item311: [2000, 10]
+    $expectedFolderStats = $this->_createItemWithStats('item311', $folder31, 2000, 10, $expectedFolderStats, $folder3);
+    // item312: [7000, 7]
+    $expectedFolderStats = $this->_createItemWithStats('item312', $folder31, 7000, 7, $expectedFolderStats, $folder3);
+    // subfolder32
+    $folder32 = $this->Folder->createFolder('subfolder32', '', $folder3->getFolderId());
+    // item321: [2000, 200]
+    $expectedFolderStats = $this->_createItemWithStats('item321', $folder32, 2000, 200, $expectedFolderStats, $folder3);
+    // subfolder321
+    $folder321 = $this->Folder->createFolder('subfolder321', '', $folder32->getFolderId());
+    // item3211: [4700, 40]
+    $expectedFolderStats = $this->_createItemWithStats('item3211', $folder321, 4700, 40, $expectedFolderStats, $folder3);
+
     // folder 4 is read for all users because of anonymous group
     $folder4 = $this->Folder->createFolder('curateFolder4', '', -1);
     $policies = array(true, true, true, true);
@@ -284,6 +336,9 @@ class CuratedfolderModelTest extends DatabaseTestCase
     $anonGroup = $groupModel->load(MIDAS_GROUP_ANONYMOUS_KEY);
     $folderpolicygroupModel->createPolicy($anonGroup, $folder4, MIDAS_POLICY_READ);
     $this->_ensureReadPolicy($folder4, $users, $policies);
+
+    // folder 4 [0, 0]
+    $expectedFolderStats[$folder4->getFolderId()] = array('size' => 0, 'download' => 0);
 
     // enable all folders for curation
     $folders = array($folder1, $folder2, $folder3, $folder4);
@@ -304,12 +359,15 @@ class CuratedfolderModelTest extends DatabaseTestCase
         $found = false;
         foreach($curatedFolders as $curatedFolder)
           {
-          if($expectedFolder->getFolderId() == $curatedFolder->getFolderId())
+          if($expectedFolder->getFolderId() == $curatedFolder['folder_id'])
             {
             $found = true;
+            // check that stats are correct
+            $this->assertEquals($expectedFolderStats[$curatedFolder['folder_id']]['download'], $curatedFolder['download'], "Did not find expected download value for curated folder with folder_id ".$curatedFolder['folder_id']);
+            $this->assertEquals($expectedFolderStats[$curatedFolder['folder_id']]['size'], $curatedFolder['size'], "Did not find expected size value for curated folder with folder_id ".$curatedFolder['folder_id']);
             }
           }
-        $this->assertTrue($found, "Did not find a match in the curated folders for expected folder with id ".$curatedFolder->getFolderId());
+        $this->assertTrue($found, "Did not find a match in the curated folders for expected folder with id ".$curatedFolder['folder_id']);
         }
       }
 
@@ -320,5 +378,9 @@ class CuratedfolderModelTest extends DatabaseTestCase
       }
 
     }
+
+
+
+
 
   }

--- a/tests/models/base/CuratedfolderModelTest.php
+++ b/tests/models/base/CuratedfolderModelTest.php
@@ -365,6 +365,7 @@ class CuratedfolderModelTest extends DatabaseTestCase
             // check that stats are correct
             $this->assertEquals($expectedFolderStats[$curatedFolder['folder_id']]['download'], $curatedFolder['download'], "Did not find expected download value for curated folder with folder_id ".$curatedFolder['folder_id']);
             $this->assertEquals($expectedFolderStats[$curatedFolder['folder_id']]['size'], $curatedFolder['size'], "Did not find expected size value for curated folder with folder_id ".$curatedFolder['folder_id']);
+            $this->assertEquals($curatedFolder['curation_state'], CURATE_STATE_CONSTRUCTION, "Did not find expected curation_state for curated folder with folder_id ".$curatedFolder['folder_id']);
             }
           }
         $this->assertTrue($found, "Did not find a match in the curated folders for expected folder with id ".$curatedFolder['folder_id']);

--- a/tests/models/base/CuratedfolderModelTest.php
+++ b/tests/models/base/CuratedfolderModelTest.php
@@ -205,6 +205,56 @@ class CuratedfolderModelTest extends DatabaseTestCase
     $disabled = $curatedfolderModel->disableFolderCuration($folderDao);
     }
 
+  /** testListAllCuratedFolders */
+  public function testListAllCuratedFolders()
+    {
+    // load some folders and enable them for curation
+    $folderDao = $this->Folder->load(1000);
+    $curatedfolderModel = MidasLoader::loadModel('Curatedfolder', 'curate');
+    $enabled = $curatedfolderModel->enableFolderCuration($folderDao);
 
+    $userModel = MidasLoader::loadModel('User');
+    $userDao = $userModel->load(1);
+    $curatedFolders = $curatedfolderModel->listAllCuratedFolders($userDao);
+    $found = false;
+    foreach($curatedFolders as $curated)
+      {
+      if($curated->getFolderId() == 1000)
+        {
+        $found = true;
+        $this->assertEquals($curated->getCurationState(), CURATE_STATE_CONSTRUCTION);
+        }
+      }
+    $this->assertTrue($found, 'did not find expected curated folder');
+
+    $curatedfolderDao = $curatedfolderModel->requestCurationApproval($folderDao);
+    $curatedFolders = $curatedfolderModel->listAllCuratedFolders($userDao);
+    $found = false;
+    foreach($curatedFolders as $curated)
+      {
+      if($curated->getFolderId() == 1000)
+        {
+        $found = true;
+        $this->assertEquals($curated->getCurationState(), CURATE_STATE_REQUESTED);
+        }
+      }
+    $this->assertTrue($found, 'did not find expected curated folder');
+
+    $curatedfolderDao = $curatedfolderModel->approveCurationRequest($folderDao);
+    $curatedFolders = $curatedfolderModel->listAllCuratedFolders($userDao);
+    $found = false;
+    foreach($curatedFolders as $curated)
+      {
+      if($curated->getFolderId() == 1000)
+        {
+        $found = true;
+        $this->assertEquals($curated->getCurationState(), CURATE_STATE_APPROVED);
+        }
+      }
+    $this->assertTrue($found, 'did not find expected curated folder');
+
+    // ensure this folder is not tracked for curation
+    $disabled = $curatedfolderModel->disableFolderCuration($folderDao);
+    }
 
   }

--- a/tests/models/base/ModeratorModelTest.php
+++ b/tests/models/base/ModeratorModelTest.php
@@ -38,15 +38,35 @@ class ModeratorModelTest extends DatabaseTestCase
     {
     $curationModeratorModel = MidasLoader::loadModel('Moderator', 'curate');
     $userDao = $this->User->load(1);
-    $curationModeratorDao = $curationModeratorModel->empowerCurationModerator($userDao);
-    // load the dao from the db and ensure it exists
-    $curationModeratorDao = $curationModeratorModel->load($curationModeratorDao->getModeratorId());
-    $this->assertEquals($userDao->getUserId(), $curationModeratorDao->getUserId(), 'curation moderator and user id do not match');
+    $empowered = $curationModeratorModel->empowerCurationModerator($userDao);
 
     // empower same user and make sure we aren't creating multiple rows in the table
-    $curationModeratorDao = $curationModeratorModel->empowerCurationModerator($userDao);
-    $curationModeratorDaos = $curationModeratorModel->findBy('user_id', $curationModeratorDao->getModeratorId());
+    $empowered = $curationModeratorModel->empowerCurationModerator($userDao);
+    $curationModeratorDaos = $curationModeratorModel->findBy('user_id', $userDao->getUserId());
     $this->assertEquals(count($curationModeratorDaos), 1, "too many curation moderator rows created");
+
+    $disempowered = $curationModeratorModel->disempowerCurationModerator($userDao);
     }
 
+  public function testIsCurationModerator() {
+    $curationModeratorModel = MidasLoader::loadModel('Moderator', 'curate');
+    $userDao = $this->User->load(1);
+    $empowered = $curationModeratorModel->isCurationModerator($userDao);
+    $this->assertEquals($empowered, false, "User should not be a curation moderator");
+
+    $empowered = $curationModeratorModel->empowerCurationModerator($userDao);
+    $this->assertEquals(true, $empowered, "User should have been empowered as a curation moderator");
+
+    // test an admin user
+    $adminUserDao = $this->User->load(1);
+    $this->assertEquals(true, $curationModeratorModel->isCurationModerator($userDao), "Admin user should be a curation moderator");
+
+
+    $disempowered = $curationModeratorModel->disempowerCurationModerator($userDao);
+    $this->assertEquals(true, $disempowered, "User should have been disempowered as a curation moderator");
+    $this->assertEquals(false, $curationModeratorModel->isCurationModerator($userDao), "User should not be a curation moderator");
   }
+
+
+
+}

--- a/views/dashboard/create.phtml
+++ b/views/dashboard/create.phtml
@@ -1,0 +1,46 @@
+<?php
+/*=========================================================================
+MIDDAS Server
+Copyright (c) Kitware SAS. 20 rue de la Villette. All rights reserved.
+69328 Lyon, FRANCE.
+See Copyright.txt for details.
+This software is distributed WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.  See the above copyright notices for more information.
+=========================================================================*/
+$this->headScript()->appendFile($this->coreWebroot.'/public/js/common/common.browser.js');
+?>
+<link href="<?php echo $this->moduleWebroot ?>/public/css/dashboard/curatedfolder.create.css" rel="stylesheet"
+      type="text/css"/>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+
+<form id="createCuratedFolderForm" class="genericForm" method="<?php echo $this->form['method'] ?>"
+      action="<?php echo $this->form['action'] ?>">
+    <div id='createCuratedFolderInstructions'>
+        This will create a new folder for a curated dataset, located in a specific community, and with upload access for a specific user.
+    </div>
+    <div class='communitySelect'>
+        <label for='community'>Community</label>
+        <?php echo $this->form['community']; ?>
+    </div>
+    <div class='curatedFolder'>
+        <div class='curatedFolderNameElement'>
+            <label for='name'><?php echo $this->t('Folder Name') ?></label>
+            <?php echo $this->form['name'] ?>
+        </div>
+        <div class='curatedFolderDescriptionElement'>
+            <label for='description'><?php echo $this->t('Folder Description') ?></label>
+            <?php echo $this->form['description'] ?>
+        </div>
+    </div>
+    <div class='uploadingUserSelect'>
+        <label for='uploader'>Uploading User</label>
+        <?php echo $this->form['uploader']; ?>
+    </div>
+    <div>
+        <?php echo $this->form['submit'] ?>
+    </div>
+</form>
+<div style="display: none;" id="curatedFolderJson">
+    <?php echo $this->json; ?>
+</div>

--- a/views/dashboard/create.phtml
+++ b/views/dashboard/create.phtml
@@ -8,7 +8,9 @@ This software is distributed WITHOUT ANY WARRANTY; without even
 the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.  See the above copyright notices for more information.
 =========================================================================*/
-$this->headScript()->appendFile($this->coreWebroot.'/public/js/common/common.browser.js');
+echo '<script type="text/javascript" src="'.$this->coreWebroot.'/public/js/common/common.browser.js"></script>';
+echo '<script type="text/javascript" src="'.$this->coreWebroot.'/public/js/jquery/jquery.form.js"></script>';
+echo '<script type="text/javascript" src="'.$this->moduleWebroot.'/public/js/dashboard/createcuratefolder.js"></script>';
 ?>
 <link href="<?php echo $this->moduleWebroot ?>/public/css/dashboard/curatedfolder.create.css" rel="stylesheet"
       type="text/css"/>
@@ -41,6 +43,3 @@ $this->headScript()->appendFile($this->coreWebroot.'/public/js/common/common.bro
         <?php echo $this->form['submit'] ?>
     </div>
 </form>
-<div style="display: none;" id="curatedFolderJson">
-    <?php echo $this->json; ?>
-</div>

--- a/views/dashboard/index.phtml
+++ b/views/dashboard/index.phtml
@@ -10,6 +10,7 @@ PURPOSE.  See the above copyright notices for more information.
 =========================================================================*/
 $this->headScript()->appendFile($this->moduleWebroot.'/public/js/dashboard/index.js');
 $this->headScript()->appendFile($this->coreWebroot.'/public/js/common/common.browser.js');
+$this->headScript()->appendFile($this->apiWebroot.'/public/js/common/common.ajaxapi.js');
 ?>
 <div class="viewMain">
     <div id="tabs-data">
@@ -24,7 +25,6 @@ $this->headScript()->appendFile($this->coreWebroot.'/public/js/common/common.bro
                     </thead>
                     <tbody>
                     <?php
-//var_dump($this->curatedFolders);
                     foreach ($this->curatedFolders as $curated) {
                         $size = $curated['size'];
                         $download = $curated['download'];
@@ -32,31 +32,29 @@ $this->headScript()->appendFile($this->coreWebroot.'/public/js/common/common.bro
                         $curatedfolder_id = $curated['curatedfolder_id'];
                         $name = $curated['name'];
                         $curation_state = $curated['curation_state'];
-                        echo "<tr>";
+                        echo "<tr id='curatedFolder{$this->escape($folder_id)}'>";
                         echo "  <td><a href=\"/folder/{$folder_id}\">{$name}</a></td>";
-                        echo "  <td>{$curation_state}</td>";
+                        echo "  <td class='curationState'>{$curation_state}</td>";
                         echo "  <td>{$size}</td>";
                         echo "  <td>{$download}</td>";
-                        //echo "  <td><input type='checkbox' class='curatedfolderCheckbox' type='folder' element='{$this->escape($curatedfolder_id)}' id='folderCheckbox{$this->escape($curatedfolder_id)}' /></td>";
-//                        echo "  <td><input type='checkbox' class='treeCheckbox' type='curatedfolder' element='{$this->escape($curatedfolder_id)}' id='curatedfolderCheckbox{$this->escape($curatedfolder_id)}' /></td>";
+                        echo "  <td class='curationAction'>";
                         if ($this->isAdmin) {
                            if($curation_state == CURATE_STATE_CONSTRUCTION) {
-                               echo "<td><img src=\"/core/public/images/icons/time.png\" style=\"padding-right: 5px;\">wait for request</td>";
+                               echo "<img src=\"/core/public/images/icons/time.png\" style=\"padding-right: 5px;\">wait for request";
                            } else if ($curation_state == CURATE_STATE_REQUESTED) {
-                               echo "<td><a onclick=\"midas.curate.adminApprove($curatedfolder_id);\"><img src=\"/core/public/images/icons/ok.png\" style=\"padding-right: 5px;\">approve request</a></td>";
+                               echo "<a onclick=\"midas.curate.adminApprove($folder_id);\"><img src=\"/core/public/images/icons/ok.png\" style=\"padding-right: 5px;\">approve request</a>";
                            } else if ($curation_state == CURATE_STATE_APPROVED) {
-                               echo "  <td></td>";
+                               //
                            }
                         } else {
                            if($curation_state == CURATE_STATE_CONSTRUCTION) {
-                               echo "<td><a onclick=\"midas.curate.uploaderRequestApproval($curatedfolder_id);\"><img src=\"/core/public/images/icons/log.png\" style=\"padding-right: 5px;\">request approval</a></td>";
+                               echo "<a onclick=\"midas.curate.uploaderRequestApproval($folder_id);\"><img src=\"/core/public/images/icons/lock.png\" style=\"padding-right: 5px;\">request approval</a>";
                            } else if ($curation_state == CURATE_STATE_REQUESTED) {
-                               echo "<td><img src=\"/core/public/images/icons/time.png\" style=\"padding-right: 5px;\">wait for approval</td>";
+                               echo "<img src=\"/core/public/images/icons/time.png\" style=\"padding-right: 5px;\">wait for approval";
                            } else if ($curation_state == CURATE_STATE_APPROVED) {
-                               echo "  <td></td>";
+                               //
                            }
-                       }
-
+                        }
                         echo "</tr>";
                     }
                     ?>
@@ -67,15 +65,15 @@ $this->headScript()->appendFile($this->coreWebroot.'/public/js/common/common.bro
 </div>
 <div class="viewSideBar">
     <div class='sideElementFirst genericAction'>
-        <h1>Curator Actions</h1>
-            <ul>
-            <?php if ($this->isAdmin) {
-                    echo "<li><a onclick='midas.curate.createNewCuratedFolder();'><img alt='' src='{$this->coreWebroot}/public/images/icons/folder_add.png'/> {$this->t(
+        <?php if ($this->isAdmin) {
+            echo "<h1>Curator Actions</h1>";
+            echo "<ul>";
+            echo "<li><a onclick='midas.curate.createNewCuratedFolder();'><img alt='' src='{$this->coreWebroot}/public/images/icons/folder_add.png'/> {$this->t(
                         'Create a Curated Folder'
                     )}</a></li>";
                   }
-            ?>
-            </ul>
+            echo "</ul>";
+        ?>
     </div>
     <div class="sideElement viewSelected">
        <h1><?php echo $this->t('Checked') ?><span></span></h1>

--- a/views/dashboard/index.phtml
+++ b/views/dashboard/index.phtml
@@ -1,0 +1,44 @@
+<?php
+/*=========================================================================
+MIDDAS Server
+Copyright (c) Kitware SAS. 20 rue de la Villette. All rights reserved.
+69328 Lyon, FRANCE.
+See Copyright.txt for details.
+This software is distributed WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.  See the above copyright notices for more information.
+=========================================================================*/
+$this->headScript()->appendFile($this->moduleWebroot.'/public/js/dashboard/index.js');
+?>
+<div class="viewMain">
+    <div id="tabs-data">
+
+                <table id="curateDashboardTable" class="midasTree">
+                    <thead>
+                    <th class="thDataset"><?php echo $this->t('Dataset'); ?></th>
+                    <th class="thCurationState"><?php echo $this->t('Curation State'); ?></th>
+                    <th class="thSizeBytes"><?php echo $this->t('Size Bytes'); ?></th>
+                    <th class="thDownloads"><?php echo $this->t('Downloads'); ?></th>
+                    </thead>
+                    <tbody>
+                    <?php
+                    foreach ($this->curatedFolders as $curated) {
+                        $size = $curated['size'];
+                        $download = $curated['download'];
+                        $folder_id = $curated['folder_id'];
+                        $name = $curated['name'];
+                        $curation_state = $curated['curation_state'];
+                        echo "<tr>";
+                        echo "  <td><a href=\"/folder/{$folder_id}\">{$name}</a></td>";
+                        echo "  <td>{$curation_state}</td>";
+                        echo "  <td>{$size}</td>";
+                        echo "  <td>{$download}</td>";
+                        echo "</tr>";
+                    }
+                    ?>
+
+                    </tbody>
+                </table>
+   </div>
+</div>
+

--- a/views/dashboard/index.phtml
+++ b/views/dashboard/index.phtml
@@ -9,6 +9,7 @@ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.  See the above copyright notices for more information.
 =========================================================================*/
 $this->headScript()->appendFile($this->moduleWebroot.'/public/js/dashboard/index.js');
+$this->headScript()->appendFile($this->coreWebroot.'/public/js/common/common.browser.js');
 ?>
 <div class="viewMain">
     <div id="tabs-data">
@@ -19,13 +20,16 @@ $this->headScript()->appendFile($this->moduleWebroot.'/public/js/dashboard/index
                     <th class="thCurationState"><?php echo $this->t('Curation State'); ?></th>
                     <th class="thSizeBytes"><?php echo $this->t('Size Bytes'); ?></th>
                     <th class="thDownloads"><?php echo $this->t('Downloads'); ?></th>
+                    <th class="thAction"><?php echo $this->t('Action'); ?></th>
                     </thead>
                     <tbody>
                     <?php
+//var_dump($this->curatedFolders);
                     foreach ($this->curatedFolders as $curated) {
                         $size = $curated['size'];
                         $download = $curated['download'];
                         $folder_id = $curated['folder_id'];
+                        $curatedfolder_id = $curated['curatedfolder_id'];
                         $name = $curated['name'];
                         $curation_state = $curated['curation_state'];
                         echo "<tr>";
@@ -33,12 +37,48 @@ $this->headScript()->appendFile($this->moduleWebroot.'/public/js/dashboard/index
                         echo "  <td>{$curation_state}</td>";
                         echo "  <td>{$size}</td>";
                         echo "  <td>{$download}</td>";
+                        //echo "  <td><input type='checkbox' class='curatedfolderCheckbox' type='folder' element='{$this->escape($curatedfolder_id)}' id='folderCheckbox{$this->escape($curatedfolder_id)}' /></td>";
+//                        echo "  <td><input type='checkbox' class='treeCheckbox' type='curatedfolder' element='{$this->escape($curatedfolder_id)}' id='curatedfolderCheckbox{$this->escape($curatedfolder_id)}' /></td>";
+                        if ($this->isAdmin) {
+                           if($curation_state == CURATE_STATE_CONSTRUCTION) {
+                               echo "<td><img src=\"/core/public/images/icons/time.png\" style=\"padding-right: 5px;\">wait for request</td>";
+                           } else if ($curation_state == CURATE_STATE_REQUESTED) {
+                               echo "<td><a onclick=\"midas.curate.adminApprove($curatedfolder_id);\"><img src=\"/core/public/images/icons/ok.png\" style=\"padding-right: 5px;\">approve request</a></td>";
+                           } else if ($curation_state == CURATE_STATE_APPROVED) {
+                               echo "  <td></td>";
+                           }
+                        } else {
+                           if($curation_state == CURATE_STATE_CONSTRUCTION) {
+                               echo "<td><a onclick=\"midas.curate.uploaderRequestApproval($curatedfolder_id);\"><img src=\"/core/public/images/icons/log.png\" style=\"padding-right: 5px;\">request approval</a></td>";
+                           } else if ($curation_state == CURATE_STATE_REQUESTED) {
+                               echo "<td><img src=\"/core/public/images/icons/time.png\" style=\"padding-right: 5px;\">wait for approval</td>";
+                           } else if ($curation_state == CURATE_STATE_APPROVED) {
+                               echo "  <td></td>";
+                           }
+                       }
+
                         echo "</tr>";
                     }
                     ?>
 
                     </tbody>
                 </table>
-   </div>
+    </div>
 </div>
-
+<div class="viewSideBar">
+    <div class='sideElementFirst genericAction'>
+        <h1>Curator Actions</h1>
+            <ul>
+            <?php if ($this->isAdmin) {
+                    echo "<li><a onclick='midas.curate.createNewCuratedFolder();'><img alt='' src='{$this->coreWebroot}/public/images/icons/folder_add.png'/> {$this->t(
+                        'Create a Curated Folder'
+                    )}</a></li>";
+                  }
+            ?>
+            </ul>
+    </div>
+    <div class="sideElement viewSelected">
+       <h1><?php echo $this->t('Checked') ?><span></span></h1>
+       <span></span>
+    </div>
+</div>


### PR DESCRIPTION
This allows for a simplified workflow, and all interactions are through the Curation Dashboard.
1. Admin User creates a Community Folder tracked under curation, in the `construction` state, tied to a User designated with uploading ability.  The uploading User has `write` access, and no other access to the Folder is granted.
2. The uploading User can upload data into the folder, and when satisfied, requests curation approval.  This removes the `write` access for the uploading User, replacing it with `read` access.  The Folder is now in `requested` state.
3. Admin User approves Folder curation, the Folder is now in `approved` state.  All individual access to the Folder is removed, Community Members gain `read` access.
